### PR TITLE
Tar up rootfs with certs for use with GrootFS

### DIFF
--- a/jobs/cflinuxfs2-rootfs-setup/templates/pre-start
+++ b/jobs/cflinuxfs2-rootfs-setup/templates/pre-start
@@ -4,6 +4,7 @@
 CONF_DIR=/var/vcap/jobs/cflinuxfs2-rootfs-setup/config
 ROOTFS_PACKAGE=/var/vcap/packages/cflinuxfs2
 ROOTFS_DIR=$ROOTFS_PACKAGE/rootfs
+ROOTFS_TAR=$ROOTFS_PACKAGE/rootfs.tar
 
 if [ ! -d $ROOTFS_DIR ]; then
   mkdir -p $ROOTFS_DIR
@@ -42,3 +43,4 @@ fi
 # change modification time to invalidate garden's image cache
 touch $ROOTFS_DIR
 
+tar -C $ROOTFS_DIR -cf $ROOTFS_TAR .

--- a/jobs/cflinuxfs2-smoke-test/templates/run.erb
+++ b/jobs/cflinuxfs2-smoke-test/templates/run.erb
@@ -7,3 +7,11 @@ CERTS=/var/vcap/jobs/cflinuxfs2-smoke-test/config/certs/trusted_ca.crt
 CERTS_COUNT=`grep "END CERTIFICATE" $CERTS | wc -l`
 FILE_COUNT=`find $CERTS_DIR -type f | wc -l`
 [ $FILE_COUNT -eq $CERTS_COUNT ]
+
+ROOTFS_TAR=/var/vcap/packages/cflinuxfs2/rootfs.tar
+ROOTFS=/var/vcap/packages/cflinuxfs2/rootfs
+ROOTFS_TMP=/tmp/rootfs
+mkdir -p $ROOTFS_TMP
+tar -C $ROOTFS_TMP -xf $ROOTFS_TAR .
+# diff doesn't compare devices correctly, so ignore /dev
+diff -r --no-dereference -x 'dev' $ROOTFS $ROOTFS_TMP


### PR DESCRIPTION
As discussed over email, we'd like to start consuming tarballs instead of directories for the new GrootFS container image manager.